### PR TITLE
Fix checkout command

### DIFF
--- a/scripts/heroku_deploy.coffee
+++ b/scripts/heroku_deploy.coffee
@@ -190,7 +190,7 @@ class GitRepo
     @run("git remote add #{remote_name} #{url}").
       then(-> that.run("git fetch #{remote_name}"))
 
-  checkout: (branch) -> @run("git checkout #{branch}")
+  checkout: (branch) -> @run("git checkout -b #{branch} origin/#{branch}")
 
   merge: (branch) -> @run("git merge #{branch}")
 


### PR DESCRIPTION
- If the branch exists on the remote environment, git will get confused
  when you try to check out the branch. Instead, check it out explicitly
  to track the origin version of the branch
